### PR TITLE
Add: error handling macros

### DIFF
--- a/devlog/15-08-2020.log
+++ b/devlog/15-08-2020.log
@@ -28,3 +28,16 @@ indexBuffer:
 
 And now, i've got a nice rectangle on my view rendered optimized with a index buffer. It's a commit.
 
+Now i'm ending with the errors handling step.
+
+This is very important because there are some type errors that doesn't cause compiling errors or errors log. So we have to mount an error notification. I've seen something similar in a graduation experiment with CUDA that the given code already had some self built error logger. So it looks like heterogenous computation raises this kind of caution.
+
+So we are using glGetError function. It detected an error and return it's error code number. From this we can retrieve the error message. And more, we can use precompiler directives called __LINE__ to specify the line that the error occurred! So this is how error loggers from compilers, interpreters and etc logs these kind of messages!
+
+I'm back. Me and my parents finished watching death note. Today Light left Death Note. Oh, they are so hyped to see what happens next.
+
+Basically created a kind of a decorator with macros that identify the occurence of errors and print the file and the line that the error occured.
+
+And hurray. That worked;
+
+A good commit for today

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,25 @@
 #define WINDOW_HEIGHT 800
 #define WINDOW_WIDTH 600
 
+#define ASSERT(x) if(!(x)) __builtin_trap();
+#define GLCall(x) GLClearError();\
+    x;\
+    ASSERT(GLLogCall(#x, __FILE__, __LINE__))
+
+static void GLClearError(){
+    // Get all errors. It will iterate till there's no errors in queue
+    while(glGetError() != GL_NO_ERROR);
+}
+
+static bool GLLogCall(const char* function, const char* file, int line){
+    while(GLenum error = glGetError()){
+        std::cout << "[OpenGL Error] (" << error << "):" << function << " " << file
+        << ":" << line << std::endl;
+        return false;
+    }
+    return true;
+}
+
 struct ShaderProgramSource{
     std::string VertexSource;
     std::string FragmentSource;
@@ -48,19 +67,19 @@ static ShaderProgramSource ParseShader(const std::string& filepath){
 static unsigned int CompileShader(unsigned int type, const std::string& source){
     unsigned int id = glCreateShader(type);
     const char* src = source.c_str();
-    glShaderSource(id, 1, &src, nullptr);
-    glCompileShader(id);
+    GLCall(glShaderSource(id, 1, &src, nullptr));
+    GLCall(glCompileShader(id));
 
     int result;
-    glGetShaderiv(id, GL_COMPILE_STATUS, &result);
+    GLCall(glGetShaderiv(id, GL_COMPILE_STATUS, &result));
     if(result == GL_FALSE){
         int length;
-        glGetShaderiv(id, GL_INFO_LOG_LENGTH, &length);
+        GLCall(glGetShaderiv(id, GL_INFO_LOG_LENGTH, &length));
         char* message = (char*)alloca(length * sizeof(char));
-        glGetShaderInfoLog(id, length, &length, message);
+        GLCall(glGetShaderInfoLog(id, length, &length, message));
         std::cout << "Failed to compile " << (type == GL_VERTEX_SHADER ? "vertex" : "fragment") << " shader" << std::endl;
         std::cout << message << std::endl;
-        glDeleteShader(id);
+        GLCall(glDeleteShader(id));
         return 0;
     }
     return id;
@@ -71,14 +90,14 @@ static int CreateShader(const std::string& vertexShader, const std::string& frag
     unsigned int vs = CompileShader(GL_VERTEX_SHADER, vertexShader);
     unsigned int fs = CompileShader(GL_FRAGMENT_SHADER, fragmentShader);
 
-    glAttachShader(program, vs);
-    glAttachShader(program, fs);
+    GLCall(glAttachShader(program, vs));
+    GLCall(glAttachShader(program, fs));
 
-    glLinkProgram(program);
-    glValidateProgram(program);
+    GLCall(glLinkProgram(program));
+    GLCall(glValidateProgram(program));
 
-    glDeleteShader(vs);
-    glDeleteShader(fs);
+    GLCall(glDeleteShader(vs));
+    GLCall(glDeleteShader(fs));
 
     return program;
 }
@@ -92,11 +111,11 @@ int main(){
 
     window = glfwCreateWindow(WINDOW_HEIGHT, WINDOW_WIDTH, "Game Engine", NULL, NULL);
     if (!window){
-        glfwTerminate();
+        GLCall(glfwTerminate());
         return -1;
     }
 
-    glfwMakeContextCurrent(window);
+    GLCall(glfwMakeContextCurrent(window));
 
     if(glewInit() != GLEW_OK){
         std::cout << "Error in glewInit()" << std::endl;
@@ -117,17 +136,17 @@ int main(){
     };
 
     unsigned int vertexBuffer;
-    glGenBuffers(1, &vertexBuffer);
-    glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
-    glBufferData(GL_ARRAY_BUFFER, 8 * sizeof(float), positions, GL_STATIC_DRAW);
+    GLCall(glGenBuffers(1, &vertexBuffer));
+    GLCall(glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer));
+    GLCall(glBufferData(GL_ARRAY_BUFFER, 8 * sizeof(float), positions, GL_STATIC_DRAW));
 
-    glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(float) * 2, 0);
+    GLCall(glEnableVertexAttribArray(0));
+    GLCall(glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(float) * 2, 0));
 
     unsigned int indexBufferObject;
-    glGenBuffers(1, &indexBufferObject);
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexBufferObject);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, 6 * sizeof(float), indices, GL_STATIC_DRAW);
+    GLCall(glGenBuffers(1, &indexBufferObject));
+    GLCall(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexBufferObject));
+    GLCall(glBufferData(GL_ELEMENT_ARRAY_BUFFER, 6 * sizeof(float), indices, GL_STATIC_DRAW));
 
     ShaderProgramSource source = ParseShader("../src/res/shaders/Basic.shader");
 
@@ -139,15 +158,13 @@ int main(){
     unsigned int shader = CreateShader(source.VertexSource, source.FragmentSource);
     glUseProgram(shader);
 
-    // glBindBuffer(GL_ARRAY_BUFFER, 0);
-
     while(!glfwWindowShouldClose(window)){
-        glClear(GL_COLOR_BUFFER_BIT);
+        GLCall(glClear(GL_COLOR_BUFFER_BIT));
 
-        glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, NULL);
+        GLCall(glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, NULL));
 
-        glfwSwapBuffers(window);
-        glfwPollEvents();
+        GLCall(glfwSwapBuffers(window));
+        GLCall(glfwPollEvents());
     }
 
 


### PR DESCRIPTION
- Added error handlers macros that wraps a openGL call and prints the file and the line that the error occurred.
- Directive from now on: Every openGL function call from GLEW should be wrapped by GLCall macro.
![Captura de tela de 2020-08-15 23-20-27](https://user-images.githubusercontent.com/6313981/90325119-19b5a800-df4e-11ea-8b4a-6c3d97969cef.png)

Message for proposital error.